### PR TITLE
Added location option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ embulk gem install embulk-input-bigquery_extract_files
 
 - **project**: Google Cloud Platform (gcp) project id (string, required)
 - **json_keyfile**: gcp service account's private key with json (string, required)
+- **location**: location of bigquery dataset and temp_dataset. see : https://cloud.google.com/bigquery/docs/locations (Optional) (string, default: `US`)
 - **gcs_uri**: bigquery result saved uri. bucket and path names parsed from this uri.  (string, required)
 - **temp_local_path**: extract files download directory in local machine (string, required)
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
     provided
 }
 
-version = "0.0.10"
+version = "0.0.11"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
@@ -22,11 +22,12 @@ dependencies {
     compile ("org.embulk:embulk-core:0.8.36")
     provided("org.embulk:embulk-core:0.8.36")
     
-    compile "com.google.http-client:google-http-client-jackson2:1.21.0"
+    compile "com.google.guava:guava:16+"
+    compile "com.google.http-client:google-http-client-jackson2:1.28.0"
     //compile ('com.google.apis:google-api-services-bigquery:v2-rev363-1.23.0') {exclude module: "guava-jdk5"}
-    compile ('com.google.apis:google-api-services-bigquery:v2-rev402-1.25.0') {exclude module: "guava-jdk5"}
+    compile ('com.google.apis:google-api-services-bigquery:v2-rev429-1.25.0') {exclude module: "guava-jdk5"}
     //compile ("com.google.apis:google-api-services-storage:v1-rev59-1.21.0") {exclude module: "guava-jdk5"}
-    compile ("com.google.apis:google-api-services-storage:v1-rev136-1.25.0") {exclude module: "guava-jdk5"}
+    compile ("com.google.apis:google-api-services-storage:v1-rev150-1.25.0") {exclude module: "guava-jdk5"}
     
     testCompile "junit:junit:4.+"
     testCompile "org.embulk:embulk-core:0.8.36:tests"

--- a/src/main/java/org/embulk/input/bigquery_export_gcs/BigqueryExportGcsFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/bigquery_export_gcs/BigqueryExportGcsFileInputPlugin.java
@@ -60,6 +60,10 @@ public class BigqueryExportGcsFileInputPlugin implements FileInputPlugin
         @Config("json_keyfile")
         public String getJsonKeyfile();
         
+        @Config("location")
+        @ConfigDefault("\"US\"")
+        public Optional<String> getLocation();
+
         @Config("dataset")
         @ConfigDefault("null")
         public Optional<String> getDataset();

--- a/src/main/java/org/embulk/input/bigquery_export_gcs/BigqueryExportUtils.java
+++ b/src/main/java/org/embulk/input/bigquery_export_gcs/BigqueryExportUtils.java
@@ -33,7 +33,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Strings;
 import com.google.api.services.bigquery.Bigquery;
 import com.google.api.services.bigquery.Bigquery.Jobs.Insert;
 import com.google.api.services.bigquery.Bigquery.Tabledata;
@@ -143,7 +143,7 @@ public class BigqueryExportUtils
 
 		log.info("query to Table jobId : {} : waiting for job end...",jobId);
 		
-		Job lastJob = waitForJob(bigquery, task.getProject(), jobId, task.getBigqueryJobWaitingSecond().get());
+		Job lastJob = waitForJob(bigquery, task.getProject(), jobId, task.getLocation().get(), task.getBigqueryJobWaitingSecond().get());
 		
 		log.debug("waiting for job end....... {}", lastJob.toPrettyString());
 	}
@@ -339,21 +339,21 @@ public class BigqueryExportUtils
 		log.info("extract jobId : {}",jobId);
 		log.debug("waiting for job end....... ");
 		
-		Job lastJob = waitForJob(bigquery, task.getProject(), jobId, task.getBigqueryJobWaitingSecond().get());
+		Job lastJob = waitForJob(bigquery, task.getProject(), jobId, task.getLocation().get(), task.getBigqueryJobWaitingSecond().get());
 		
 		log.info("table extract result : {}",lastJob.toPrettyString());
 		
 		return embulkSchema;
     }
 
-    public static Job waitForJob(Bigquery bigquery, String project, String jobId, int bigqueryJobWaitingSecond) throws IOException, InterruptedException{
+    public static Job waitForJob(Bigquery bigquery, String project, String jobId, String location, int bigqueryJobWaitingSecond) throws IOException, InterruptedException{
     	int maxAttempts = bigqueryJobWaitingSecond;
 		int initialRetryDelay = 1000; // ms
 		Job pollingJob = null;	
 		log.info("waiting for job end : {}",jobId);
 		int tryCnt = 0;
         for (tryCnt=0; tryCnt < maxAttempts; tryCnt++){
-            pollingJob = bigquery.jobs().get(project, jobId).execute();
+            pollingJob = bigquery.jobs().get(project, jobId).setLocation(location).execute();
             String state = pollingJob.getStatus().getState();
             log.debug("Job Status {} : {}",jobId, state);
             


### PR DESCRIPTION
Added `location` option.
I added this option because BigQuery job fails with `404 Not found` error, when I use dataset/temp_dataset in [regional location](https://cloud.google.com/bigquery/docs/locations) (ex. `asia-northeast1`).

This pull request's implementation is working fine in my [service](https://trocco.io)'s production environment.